### PR TITLE
Replace SETTINGS; split out normalizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ MANIFEST
 __pycache__/
 .mypy_cache/
 .pytype/
+.scratch/
 .venv/
 audiolibrarian.egg-info/
 dist/
@@ -14,8 +15,6 @@ library/
 new_library/
 workdir/
 venv/
-
-NOTES.md
 
 # MkDocs build output
 site/

--- a/.idea/audiolibrarian.iml
+++ b/.idea/audiolibrarian.iml
@@ -6,6 +6,7 @@
       <excludeFolder url="file://$MODULE_DIR$/.venv" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/library" />
+      <excludeFolder url="file://$MODULE_DIR$/.scratch" />
     </content>
     <orderEntry type="jdk" jdkName="Python 3.13 virtualenv at ~/scm/audiolibrarian/.venv" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dev = [
     "pymarkdownlnt",
     "pytest",
     "pytest-env",
+    "pytest-mock",
     "ruff",
     "types-pyyaml",
     "types-requests",
@@ -49,7 +50,7 @@ readme = "README.md"
 requires-python = ">=3.12,<3.14"
 
 [project.scripts]
-audiolibrarian = "audiolibrarian:cli.main"
+audiolibrarian = "audiolibrarian.entrypoints.cli:main"
 
 [project.urls]
 Repository = "https://github.com/toadstule/audiolibrarian"

--- a/src/audiolibrarian/audiosource.py
+++ b/src/audiolibrarian/audiosource.py
@@ -27,8 +27,7 @@ from collections.abc import Callable  # noqa: TC003
 
 import discid
 
-from audiolibrarian import audiofile, records, sh, text
-from audiolibrarian.settings import SETTINGS
+from audiolibrarian import audiofile, config, records, sh, text
 
 log = logging.getLogger(__name__)
 
@@ -93,10 +92,10 @@ class AudioSource(abc.ABC):
 class CDAudioSource(AudioSource):
     """AudioSource from a compact disc."""
 
-    def __init__(self) -> None:
+    def __init__(self, settings: config.Settings) -> None:
         """Initialize a CDAudioSource."""
         super().__init__()
-        self._cd = discid.read(SETTINGS.discid_device, features=["mcn"])
+        self._cd = discid.read(settings.discid_device, features=["mcn"])
 
     def get_search_data(self) -> dict[str, str]:
         """Return a dictionary of search data useful for doing a MusicBrainz search."""

--- a/src/audiolibrarian/commands.py
+++ b/src/audiolibrarian/commands.py
@@ -22,7 +22,7 @@ import pathlib
 import re
 from typing import Any
 
-from audiolibrarian import __version__, audiofile, audiosource, base, genremanager
+from audiolibrarian import __version__, audiofile, audiosource, base, config, genremanager
 
 log = logging.getLogger(__name__)
 
@@ -56,9 +56,9 @@ class Convert(_Command, base.Base):
     parser.add_argument("--disc", "-d", help="format: x/y: disc x of y for multi-disc release")
     parser.add_argument("filename", nargs="+", help="directory name or audio file name")
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Convert command handler."""
-        super().__init__(args)
+        super().__init__(args, settings)
         self._source_is_cd = False
         self._audio_source = audiosource.FilesAudioSource([pathlib.Path(x) for x in args.filename])
         self._get_tag_info()
@@ -88,9 +88,9 @@ class Genre(_Command):
     parser_action.add_argument("--tag", action="store_true", help="update tags")
     parser_action.add_argument("--update", action="store_true", help="update MusicBrainz")
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Genre command handler."""
-        genremanager.GenreManager(args)
+        genremanager.GenreManager(args=args, settings=settings.musicbrainz)
 
 
 class Manifest(_Command, base.Base):
@@ -111,9 +111,9 @@ class Manifest(_Command, base.Base):
     parser.add_argument("--disc", "-d", help="format: x/y: disc x of y for multi-disc release")
     parser.add_argument("filename", nargs="+", help="directory name or audio file name")
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Manifest command handler."""
-        super().__init__(args)
+        super().__init__(args, settings)
         self._source_is_cd = args.cd
         self._audio_source = audiosource.FilesAudioSource([pathlib.Path(x) for x in args.filename])
         source_filenames = self._audio_source.get_source_filenames()
@@ -139,9 +139,9 @@ class Reconvert(_Command, base.Base):
     parser = argparse.ArgumentParser()
     parser.add_argument("directories", nargs="+", help="source directories")
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Reconvert command handler."""
-        super().__init__(args)
+        super().__init__(args, settings)
         self._source_is_cd = False
         manifest_paths = self._find_manifests(args.directories)
         count = len(manifest_paths)
@@ -172,9 +172,9 @@ class Rename(_Command, base.Base):
     parser.add_argument("--dry-run", action="store_true", help="don't actually rename files")
     parser.add_argument("directories", nargs="+", help="audio file directories")
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Rename command handler."""
-        super().__init__(args)
+        super().__init__(args, settings)
         self._source_is_cd = False
         print("Finding audio files...")
         for audio_file in self._find_audio_files(args.directories):
@@ -233,11 +233,11 @@ class Rip(_Command, base.Base):
     parser.add_argument("--mb-release-id", help="MusicBrainz release ID")
     parser.add_argument("--disc", "-d", help="x/y: disc x of y; multi-disc release")
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Rip command handler."""
-        super().__init__(args)
+        super().__init__(args, settings)
         self._source_is_cd = True
-        self._audio_source = audiosource.CDAudioSource()
+        self._audio_source = audiosource.CDAudioSource(settings)
         self._get_tag_info()
         self._convert()
         self._write_manifest()
@@ -254,9 +254,9 @@ class Version(_Command):
     command = "version"
     help = "display the program version"
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.Settings) -> None:
         """Initialize a Version command handler."""
-        _ = args
+        del args, settings  # Unused.
         print(f"audiolibrarian {__version__}")
 
 

--- a/src/audiolibrarian/config.py
+++ b/src/audiolibrarian/config.py
@@ -48,28 +48,33 @@ import xdg_base_dirs
 logger = logging.getLogger(__name__)
 
 
-class MusicBrainzSettings(pydantic_settings.BaseSettings):
+class EmptySettings(pydantic.BaseModel):
+    """Empty settings."""
+
+
+class MusicBrainzSettings(pydantic.BaseModel):
     """Configuration settings for MusicBrainz."""
 
     password: pydantic.SecretStr = pydantic.SecretStr("")
     username: str = ""
     rate_limit: pydantic.PositiveFloat = 1.5  # Seconds between requests.
+    work_dir: pathlib.Path = xdg_base_dirs.xdg_cache_home() / "audiolibrarian"
 
 
-class NormalizeFFmpegSettings(pydantic_settings.BaseSettings):
+class NormalizeFFmpegSettings(pydantic.BaseModel):
     """Configuration settings for ffmpeg normalization."""
 
     target_level: float = -13
 
 
-class NormalizeWavegainSettings(pydantic_settings.BaseSettings):
+class NormalizeWavegainSettings(pydantic.BaseModel):
     """Configuration settings for wavegain normalization."""
 
     gain: int = 5  # dB
     preset: Literal["album", "radio"] = "radio"
 
 
-class NormalizeSettings(pydantic_settings.BaseSettings):
+class NormalizeSettings(pydantic.BaseModel):
     """Configuration settings for audio normalization."""
 
     normalizer: Literal["auto", "wavegain", "ffmpeg", "none"] = "auto"
@@ -102,13 +107,10 @@ class Settings(pydantic_settings.BaseSettings):
         dotenv_settings: pydantic_settings.PydanticBaseSettingsSource,
         file_secret_settings: pydantic_settings.PydanticBaseSettingsSource,
     ) -> tuple[pydantic_settings.PydanticBaseSettingsSource, ...]:
+        """Customize settings sources."""
         del dotenv_settings, file_secret_settings  # Unused.
         return (
+            init_settings,  # Used for tests.
             env_settings,
             pydantic_settings.YamlConfigSettingsSource(settings_cls),
-            init_settings,
         )
-
-
-SETTINGS = Settings()
-__all__ = ["SETTINGS"]

--- a/src/audiolibrarian/entrypoints/__init__.py
+++ b/src/audiolibrarian/entrypoints/__init__.py
@@ -1,0 +1,17 @@
+"""Entrypoints for audiolibrarian."""
+#
+#  Copyright (c) 2000-2025 Stephen Jibson
+#
+#  This file is part of audiolibrarian.
+#
+#  Audiolibrarian is free software: you can redistribute it and/or modify it under the terms of the
+#  GNU General Public License as published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  Audiolibrarian is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+#  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+#  the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along with audiolibrarian.
+#  If not, see <https://www.gnu.org/licenses/>.
+#

--- a/src/audiolibrarian/entrypoints/cli.py
+++ b/src/audiolibrarian/entrypoints/cli.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 from typing import Final
 
-from audiolibrarian import commands
+from audiolibrarian import commands, config
 
 log = logging.getLogger("audiolibrarian")
 
@@ -57,7 +57,7 @@ class CommandLineInterface:
             if self._args.command == cmd.command:
                 if not cmd.validate_args(self._args):
                     sys.exit(2)
-                cmd(self._args)
+                cmd(self._args, config.Settings())
                 break
         if self._args.log_level == logging.DEBUG:
             print(pathlib.Path("/proc/self/status").read_text(encoding="utf-8"))

--- a/src/audiolibrarian/genremanager.py
+++ b/src/audiolibrarian/genremanager.py
@@ -29,8 +29,7 @@ import mutagen.flac
 import mutagen.id3
 import mutagen.mp4
 
-from audiolibrarian import musicbrainz, text
-from audiolibrarian.settings import SETTINGS
+from audiolibrarian import config, musicbrainz, text
 
 log = logging.getLogger(__name__)
 
@@ -38,10 +37,11 @@ log = logging.getLogger(__name__)
 class GenreManager:
     """Manage genres."""
 
-    def __init__(self, args: argparse.Namespace) -> None:
+    def __init__(self, args: argparse.Namespace, settings: config.MusicBrainzSettings) -> None:
         """Initialize a GenreManager instance."""
         self._args = args
-        self._mb = musicbrainz.MusicBrainzSession()
+        self._settings = settings
+        self._mb = musicbrainz.MusicBrainzSession(settings=settings)
         self._paths = self._get_all_paths()
         self._paths_by_artist = self._get_paths_by_artist()
         _u, _c = self._get_genres_by_artist()
@@ -149,7 +149,7 @@ class GenreManager:
         user: dict[str, str] = {}
         community: dict[str, dict[str, Any]] = {}
         user_modified = False
-        cache_file = SETTINGS.work_dir / "user-genres.pickle"
+        cache_file = self._settings.work_dir / "user-genres.pickle"
         if cache_file.exists():
             with cache_file.open(mode="rb") as cache_file_obj:
                 user = pickle.load(cache_file_obj)  # noqa: S301

--- a/src/audiolibrarian/normalizer.py
+++ b/src/audiolibrarian/normalizer.py
@@ -1,0 +1,155 @@
+"""Audio normalization functionality using different backends."""
+#
+#  Copyright (c) 2000-2025 Stephen Jibson
+#
+#  This file is part of audiolibrarian.
+#
+#  Audiolibrarian is free software: you can redistribute it and/or modify it under the terms of the
+#  GNU General Public License as published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  Audiolibrarian is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+#  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+#  the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along with audiolibrarian.`
+#  If not, see <https://www.gnu.org/licenses/>.
+#
+
+import abc
+import logging
+import pathlib
+import shutil
+import subprocess
+from typing import Any, TypeVar
+
+import ffmpeg_normalize
+import pydantic
+
+from audiolibrarian import config
+
+log = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=pydantic.BaseModel)
+
+
+class Normalizer[T](abc.ABC):
+    """Abstract base class for audio normalizers."""
+
+    def __init__(self, settings: T) -> None:
+        """Initialize a Normalizer instance.
+
+        Args:
+            settings: The settings specific to this normalizer type.
+        """
+        self._settings: T = settings
+
+    @classmethod
+    def factory(cls, settings: config.NormalizeSettings) -> "Normalizer[Any]":
+        """Create the appropriate normalizer based on settings.
+
+        Args:
+            settings: The normalization settings.
+
+        Returns:
+            An instance of the appropriate Normalizer implementation.
+        """
+        if settings.normalizer == "none":
+            return NoOpNormalizer(config.EmptySettings())
+
+        wavegain_found = shutil.which("wavegain")
+        if settings.normalizer in ("auto", "wavegain") and wavegain_found:
+            return WaveGainNormalizer(settings.wavegain)
+
+        ffmpeg_found = shutil.which("ffmpeg")
+        if settings.normalizer in ("auto", "ffmpeg") and ffmpeg_found:
+            return FFmpegNormalizer(settings.ffmpeg)
+
+        if wavegain_found:
+            log.warning("ffmpeg not found, using wavegain for normalization")
+            return WaveGainNormalizer(settings.wavegain)
+        if ffmpeg_found:
+            log.warning("wavegain not found, using ffmpeg for normalization")
+            return FFmpegNormalizer(settings.ffmpeg)
+        log.warning("wavegain not found, ffmpeg not found, using no normalization")
+        return NoOpNormalizer(config.EmptySettings())
+
+    @abc.abstractmethod
+    def normalize(self, paths: set[pathlib.Path]) -> None:
+        """Normalize the given audio files.
+
+        Args:
+            paths: Set of audio file paths to normalize.
+
+        Raises:
+            Exception: If the normalization process fails.
+        """
+
+
+class NoOpNormalizer(Normalizer[config.EmptySettings]):
+    """No-op normalizer that does nothing."""
+
+    def normalize(self, paths: set[pathlib.Path]) -> None:
+        """Do not perform any normalization."""
+        del paths  # Unused.
+        log.info("Skipping audio normalization")
+
+
+class WaveGainNormalizer(Normalizer[config.NormalizeWavegainSettings]):
+    """Audio normalizer using wavegain."""
+
+    def normalize(self, paths: set[pathlib.Path]) -> None:
+        """Normalize audio files using wavegain.
+
+        Args:
+            paths: List of audio file paths to normalize.
+
+        Raises:
+            subprocess.CalledProcessError: If wavegain process fails.
+        """
+        if not paths:
+            return
+
+        log.info("Normalizing %d files with wavegain...", len(paths))
+
+        command = [
+            "wavegain",
+            f"--{self._settings.preset}",
+            f"--gain={self._settings.gain}",
+            "--apply",
+            *[str(f) for f in paths],
+        ]
+        result = subprocess.run(command, capture_output=True, check=False)  # noqa: S603
+        for line in str(result.stderr).split(r"\n"):
+            line_trunc = line[:137] + "..." if len(line) > 140 else line  # noqa: PLR2004
+            log.info("WAVEGAIN: %s", line_trunc)
+        result.check_returncode()  # May raise subprocess.CalledProcessError.
+
+
+class FFmpegNormalizer(Normalizer[config.NormalizeFFmpegSettings]):
+    """Audio normalizer using ffmpeg-normalize."""
+
+    def normalize(self, paths: set[pathlib.Path]) -> None:
+        """Normalize audio files using ffmpeg-normalize.
+
+        Args:
+            paths: List of audio file paths to normalize.
+
+        Raises:
+            Exception: If ffmpeg-normalize process fails.
+        """
+        if not paths:
+            return
+
+        log.info("Normalizing %d files with ffmpeg-normalize...", len(paths))
+
+        normalizer = ffmpeg_normalize.FFmpegNormalize(
+            extension="wav",
+            keep_loudness_range_target=True,
+            target_level=self._settings.target_level,
+        )
+        for path in paths:
+            normalizer.add_media_file(str(path), str(path))
+        log.info("Starting ffmpeg normalization...")
+        normalizer.run_normalization()
+        log.info("FFmpeg normalization completed successfully")

--- a/tests/test__audiolibrarian.py
+++ b/tests/test__audiolibrarian.py
@@ -22,7 +22,7 @@ from typing import Final
 
 import pytest
 
-from audiolibrarian import base
+from audiolibrarian import base, config
 
 test_data_path = (Path(__file__).parent / "test_data").resolve()
 
@@ -33,9 +33,14 @@ class TestAudioLibrarian:
     AUDIO_FILE_COUNT: Final[int] = 21  # This will need updated if test files are added.
 
     @pytest.fixture
-    def al_base(self) -> base.Base:
+    def settings(self) -> config.Settings:
+        """Return a Settings instance."""
+        return config.Settings()
+
+    @pytest.fixture
+    def al_base(self, settings: config.Settings) -> base.Base:
         """Return a Base instance with a blank namespace."""
-        return base.Base(args=Namespace())
+        return base.Base(args=Namespace(), settings=settings)
 
     def test__single_media(self, al_base: base.Base) -> None:
         """Test single media."""
@@ -51,9 +56,9 @@ class TestAudioLibrarian:
         with pytest.warns(RuntimeWarning):
             al_base._summary()
 
-    def test__multi_media(self) -> None:
+    def test__multi_media(self, settings: config.Settings) -> None:
         """Test multi-media."""
-        al = base.Base(args=Namespace(disc="2/3"))
+        al = base.Base(args=Namespace(disc="2/3"), settings=settings)
 
         assert al._multi_disc
         searcher = al._get_searcher()
@@ -100,10 +105,13 @@ class TestAudioLibrarian:
         ],
     )
     def test__get_searcher(
-        self, namespace: Namespace, expected: tuple[str, str, str, str, str, str]
+        self,
+        namespace: Namespace,
+        settings: config.Settings,
+        expected: tuple[str, str, str, str, str, str],
     ) -> None:
         """Test searcher."""
-        al_base = base.Base(args=namespace)
+        al_base = base.Base(args=namespace, settings=settings)
         searcher = al_base._get_searcher()
         assert (
             searcher.artist,

--- a/tests/test__commands.py
+++ b/tests/test__commands.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 # noinspection PyProtectedMember
-from audiolibrarian import __version__, commands
+from audiolibrarian import __version__, commands, config
 
 test_data_path = (Path(__file__).parent / "test_data").resolve()
 
@@ -30,9 +30,14 @@ test_data_path = (Path(__file__).parent / "test_data").resolve()
 class TestCommands:
     """Test commands."""
 
-    def test__version(self, capsys: pytest.CaptureFixture[str]) -> None:
+    @pytest.fixture
+    def settings(self) -> config.Settings:
+        """Return a Settings instance."""
+        return config.Settings()
+
+    def test__version(self, capsys: pytest.CaptureFixture[str], settings: config.Settings) -> None:
         """Test version command."""
-        commands.Version(Namespace())
+        commands.Version(args=Namespace(), settings=settings)
         output: str = capsys.readouterr().out.strip()
         assert output == f"audiolibrarian {__version__}"
 

--- a/tests/test__misc.py
+++ b/tests/test__misc.py
@@ -34,7 +34,7 @@ import pytest
 #  You should have received a copy of the GNU General Public License along with audiolibrarian.
 #  If not, see <https://www.gnu.org/licenses/>.
 #
-from audiolibrarian import cli
+from audiolibrarian.entrypoints import cli
 
 
 class TestMisc:

--- a/tests/test__normalizer.py
+++ b/tests/test__normalizer.py
@@ -1,0 +1,202 @@
+"""Tests for the normalizer module."""
+
+#
+#  Copyright (c) 2000-2025 Stephen Jibson
+#
+#  This file is part of audiolibrarian.
+#
+#  Audiolibrarian is free software: you can redistribute it and/or modify it under the terms of the
+#  GNU General Public License as published by the Free Software Foundation, either version 3 of the
+#  License, or (at your option) any later version.
+#
+#  Audiolibrarian is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+#  without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+#  the GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License along with audiolibrarian.
+#  If not, see <https://www.gnu.org/licenses/>.
+#
+import logging
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+import pytest_mock
+from _pytest.monkeypatch import MonkeyPatch
+
+from audiolibrarian import config
+from audiolibrarian import normalizer as normalizer_
+
+
+def test_noop_normalizer(tmp_path: pathlib.Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Test that NoOpNormalizer does nothing."""
+    # Setup logging capture
+    caplog.set_level(logging.INFO)
+
+    # Create a test file
+    test_file = tmp_path / "test.wav"
+    test_file.touch()
+
+    # Initialize and call normalizer
+    normalizer = normalizer_.NoOpNormalizer(config.EmptySettings())
+    normalizer.normalize({test_file})
+
+    # Verify no changes were made and log message was emitted
+    assert test_file.exists()
+    log_messages = [record.message for record in caplog.records]
+    assert any("Skipping audio normalization" in msg for msg in log_messages)
+
+
+def test_wavegain_normalizer_success(
+    tmp_path: pathlib.Path, mocker: pytest_mock.MockFixture
+) -> None:
+    """Test WaveGainNormalizer with successful execution."""
+    # Setup
+    test_file = tmp_path / "test.wav"
+    test_file.touch()
+
+    # Mock subprocess.run to simulate successful execution
+    mock_run = mocker.patch("subprocess.run")
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stderr = b"Normalization complete\n"
+
+    # Execute
+    settings = config.NormalizeWavegainSettings(gain=5, preset="radio")
+    normalizer = normalizer_.WaveGainNormalizer(settings)
+    normalizer.normalize({test_file})
+
+    # Verify command was called correctly
+    mock_run.assert_called_once()
+    args, kwargs = mock_run.call_args
+    assert "wavegain" in args[0][0]
+    assert "--radio" in args[0]
+    assert "--gain=5" in args[0]
+    assert "--apply" in args[0]
+    assert str(test_file) in args[0]
+
+
+def test_ffmpeg_normalizer_success(
+    tmp_path: pathlib.Path, mocker: pytest_mock.MockFixture
+) -> None:
+    """Test FFmpegNormalizer with successful execution."""
+    # Setup
+    test_file = tmp_path / "test.wav"
+    test_file.touch()
+
+    # Mock FFmpegNormalize
+    mock_ffmpeg = mocker.patch("ffmpeg_normalize.FFmpegNormalize")
+
+    # Execute
+    settings = config.NormalizeFFmpegSettings(target_level=-13.0)
+    normalizer = normalizer_.FFmpegNormalizer(settings)
+    normalizer.normalize({test_file})
+
+    # Verify FFmpegNormalize was called correctly
+    mock_ffmpeg.assert_called_once_with(
+        extension="wav",
+        keep_loudness_range_target=True,
+        target_level=-13.0,
+    )
+    mock_ffmpeg.return_value.add_media_file.assert_called_once_with(str(test_file), str(test_file))
+    mock_ffmpeg.return_value.run_normalization.assert_called_once()
+
+
+def test_normalizer_factory_none() -> None:
+    """Test factory returns NoOpNormalizer when normalizer is 'none'."""
+    settings = config.NormalizeSettings(normalizer="none")
+    normalizer = normalizer_.Normalizer.factory(settings)
+    assert isinstance(normalizer, normalizer_.NoOpNormalizer)
+
+
+def test_normalizer_factory_wavegain(monkeypatch: MonkeyPatch) -> None:
+    """Test factory returns WaveGainNormalizer when wavegain is available."""
+    # Mock shutil.which to simulate wavegain being available
+    monkeypatch.setattr(
+        shutil, "which", lambda x: "/fake/path/wavegain" if x == "wavegain" else None
+    )
+
+    settings = config.NormalizeSettings(normalizer="wavegain")
+    normalizer = normalizer_.Normalizer.factory(settings)
+    assert isinstance(normalizer, normalizer_.WaveGainNormalizer)
+
+
+def test_normalizer_factory_ffmpeg(monkeypatch: MonkeyPatch) -> None:
+    """Test factory returns FFmpegNormalizer when ffmpeg is available."""
+    # Mock shutil.which to simulate ffmpeg being available
+    monkeypatch.setattr(shutil, "which", lambda x: "/fake/path/ffmpeg" if x == "ffmpeg" else None)
+
+    settings = config.NormalizeSettings(normalizer="ffmpeg")
+    normalizer = normalizer_.Normalizer.factory(settings)
+    assert isinstance(normalizer, normalizer_.FFmpegNormalizer)
+
+
+def test_normalizer_factory_auto_wavegain(monkeypatch: MonkeyPatch) -> None:
+    """Test factory returns WaveGainNormalizer in auto mode when wavegain is available."""
+    # Mock shutil.which to simulate wavegain being available
+    monkeypatch.setattr(
+        shutil, "which", lambda x: "/fake/path/wavegain" if x == "wavegain" else None
+    )
+
+    settings = config.NormalizeSettings(normalizer="auto")
+    normalizer = normalizer_.Normalizer.factory(settings)
+    assert isinstance(normalizer, normalizer_.WaveGainNormalizer)
+
+
+def test_normalizer_factory_auto_ffmpeg(monkeypatch: MonkeyPatch) -> None:
+    """Test factory returns FFmpegNormalizer in auto mode when ffmpeg is available."""
+
+    # Mock shutil.which to simulate only ffmpeg being available
+    def mock_which(cmd: str) -> str | None:
+        if cmd == "wavegain":
+            return None
+        if cmd == "ffmpeg":
+            return "/fake/path/ffmpeg"
+        return None
+
+    monkeypatch.setattr(shutil, "which", mock_which)
+
+    settings = config.NormalizeSettings(normalizer="auto")
+    normalizer = normalizer_.Normalizer.factory(settings)
+    assert isinstance(normalizer, normalizer_.FFmpegNormalizer)
+
+
+def test_normalizer_factory_auto_fallback(monkeypatch: MonkeyPatch) -> None:
+    """Test factory falls back to NoOpNormalizer when no normalizers are available."""
+    # Mock shutil.which to simulate no normalizers available
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+
+    settings = config.NormalizeSettings(normalizer="auto")
+    normalizer = normalizer_.Normalizer.factory(settings)
+    assert isinstance(normalizer, normalizer_.NoOpNormalizer)
+
+
+def test_wavegain_normalizer_error_handling(
+    tmp_path: pathlib.Path, mocker: pytest_mock.MockFixture, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test WaveGainNormalizer error handling."""
+    # Setup
+    caplog.set_level(logging.INFO)
+    test_file = tmp_path / "test.wav"
+    test_file.touch()
+
+    # Mock subprocess.run to simulate failure
+    mock_run = mocker.patch("subprocess.run")
+    mock_result = mocker.Mock()
+    mock_result.returncode = 1
+    mock_result.stderr = b"Error: File not found\n"
+    mock_result.check_returncode.side_effect = subprocess.CalledProcessError(
+        returncode=1,
+        cmd=["wavegain", "--album", "--gain=7.5", "--apply", str(test_file)],
+        stderr=b"Error: File not found\n",
+    )
+    mock_run.return_value = mock_result
+
+    # Execute & Verify
+    settings = config.NormalizeWavegainSettings()
+    normalizer = normalizer_.WaveGainNormalizer(settings)
+    with pytest.raises(subprocess.CalledProcessError):
+        normalizer.normalize({test_file})
+
+    # Verify the error was logged
+    assert any("Error:" in record.message for record in caplog.records)

--- a/uv.lock
+++ b/uv.lock
@@ -63,6 +63,7 @@ dev = [
     { name = "pymarkdownlnt" },
     { name = "pytest" },
     { name = "pytest-env" },
+    { name = "pytest-mock" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -96,6 +97,7 @@ dev = [
     { name = "pymarkdownlnt" },
     { name = "pytest" },
     { name = "pytest-env" },
+    { name = "pytest-mock" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-requests" },
@@ -113,15 +115,15 @@ wheels = [
 
 [[package]]
 name = "backrefs"
-version = "5.8"
+version = "5.9"
 source = { registry = "https://pypi.jibson.com/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/46/caba1eb32fa5784428ab401a5487f73db4104590ecd939ed9daaf18b47e0/backrefs-5.8.tar.gz", hash = "sha256:2cab642a205ce966af3dd4b38ee36009b31fa9502a35fd61d59ccc116e40a6bd", size = 6773994, upload-time = "2025-02-25T18:15:32.003Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/eb/a7/312f673df6a79003279e1f55619abbe7daebbb87c17c976ddc0345c04c7b/backrefs-5.9.tar.gz", hash = "sha256:808548cb708d66b82ee231f962cb36faaf4f2baab032f2fbb783e9c2fdddaa59", size = 5765857, upload-time = "2025-06-22T19:34:13.97Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/cb/d019ab87fe70e0fe3946196d50d6a4428623dc0c38a6669c8cae0320fbf3/backrefs-5.8-py310-none-any.whl", hash = "sha256:c67f6638a34a5b8730812f5101376f9d41dc38c43f1fdc35cb54700f6ed4465d", size = 380337, upload-time = "2025-02-25T16:53:14.607Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/86/abd17f50ee21b2248075cb6924c6e7f9d23b4925ca64ec660e869c2633f1/backrefs-5.8-py311-none-any.whl", hash = "sha256:2e1c15e4af0e12e45c8701bd5da0902d326b2e200cafcd25e49d9f06d44bb61b", size = 392142, upload-time = "2025-02-25T16:53:17.266Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/04/7b415bd75c8ab3268cc138c76fa648c19495fcc7d155508a0e62f3f82308/backrefs-5.8-py312-none-any.whl", hash = "sha256:bbef7169a33811080d67cdf1538c8289f76f0942ff971222a16034da88a73486", size = 398021, upload-time = "2025-02-25T16:53:26.378Z" },
-    { url = "https://files.pythonhosted.org/packages/04/b8/60dcfb90eb03a06e883a92abbc2ab95c71f0d8c9dd0af76ab1d5ce0b1402/backrefs-5.8-py313-none-any.whl", hash = "sha256:e3a63b073867dbefd0536425f43db618578528e3896fb77be7141328642a1585", size = 399915, upload-time = "2025-02-25T16:53:28.167Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/37/fb6973edeb700f6e3d6ff222400602ab1830446c25c7b4676d8de93e65b8/backrefs-5.8-py39-none-any.whl", hash = "sha256:a66851e4533fb5b371aa0628e1fee1af05135616b86140c9d787a2ffdf4b8fdc", size = 380336, upload-time = "2025-02-25T16:53:29.858Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4d/798dc1f30468134906575156c089c492cf79b5a5fd373f07fe26c4d046bf/backrefs-5.9-py310-none-any.whl", hash = "sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f", size = 380267, upload-time = "2025-06-22T19:34:05.252Z" },
+    { url = "https://files.pythonhosted.org/packages/55/07/f0b3375bf0d06014e9787797e6b7cc02b38ac9ff9726ccfe834d94e9991e/backrefs-5.9-py311-none-any.whl", hash = "sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf", size = 392072, upload-time = "2025-06-22T19:34:06.743Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/12/4f345407259dd60a0997107758ba3f221cf89a9b5a0f8ed5b961aef97253/backrefs-5.9-py312-none-any.whl", hash = "sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa", size = 397947, upload-time = "2025-06-22T19:34:08.172Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bf/fa31834dc27a7f05e5290eae47c82690edc3a7b37d58f7fb35a1bdbf355b/backrefs-5.9-py313-none-any.whl", hash = "sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b", size = 399843, upload-time = "2025-06-22T19:34:09.68Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ff/392bff89415399a979be4a65357a41d92729ae8580a66073d8ec8d810f98/backrefs-5.9-py39-none-any.whl", hash = "sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60", size = 380265, upload-time = "2025-06-22T19:34:12.405Z" },
 ]
 
 [[package]]
@@ -745,16 +747,16 @@ wheels = [
 
 [[package]]
 name = "pydantic-settings"
-version = "2.10.0"
+version = "2.10.1"
 source = { registry = "https://pypi.jibson.com/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/ef/3d61472b7801c896f9efd9bb8750977d9577098b05224c5c41820690155e/pydantic_settings-2.10.0.tar.gz", hash = "sha256:7a12e0767ba283954f3fd3fefdd0df3af21b28aa849c40c35811d52d682fa876", size = 172625, upload-time = "2025-06-21T13:56:55.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/85/1ea668bbab3c50071ca613c6ab30047fb36ab0da1b92fa8f17bbc38fd36c/pydantic_settings-2.10.1.tar.gz", hash = "sha256:06f0062169818d0f5524420a360d632d5857b83cffd4d42fe29597807a1614ee", size = 172583, upload-time = "2025-06-24T13:26:46.841Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/9e/fce9331fecf1d2761ff0516c5dceab8a5fd415e82943e727dc4c5fa84a90/pydantic_settings-2.10.0-py3-none-any.whl", hash = "sha256:33781dfa1c7405d5ed2b6f150830a93bb58462a847357bd8f162f8bacb77c027", size = 45232, upload-time = "2025-06-21T13:56:53.682Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f0/427018098906416f580e3cf1366d3b1abfb408a0652e9f31600c24a1903c/pydantic_settings-2.10.1-py3-none-any.whl", hash = "sha256:a60952460b99cf661dc25c29c0ef171721f98bfcb52ef8d9ea4c943d7c8cc796", size = 45235, upload-time = "2025-06-24T13:26:45.485Z" },
 ]
 
 [[package]]
@@ -822,6 +824,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.14.1"
+source = { registry = "https://pypi.jibson.com/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/28/67172c96ba684058a4d24ffe144d64783d2a270d0af0d9e792737bddc75c/pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e", size = 33241, upload-time = "2025-05-26T13:58:45.167Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/05/77b60e520511c53d1c1ca75f1930c7dd8e971d0c4379b7f4b3f9644685ba/pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0", size = 9923, upload-time = "2025-05-26T13:58:43.487Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.jibson.com/simple" }
@@ -835,11 +849,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.1.1"
 source = { registry = "https://pypi.jibson.com/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/2c/7bb1416c5620485aa793f2de31d3df393d3686aa8a8506d11e10e13c5baf/python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5", size = 39920, upload-time = "2025-03-25T10:14:56.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/18/98a99ad95133c6a6e2005fe89faedf294a748bd5dc803008059409ac9b1e/python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d", size = 20256, upload-time = "2025-03-25T10:14:55.034Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace global singleton SETTING with a model that eliminates some of the issues with globalness.
- Split normalizer into a set of classes, one for none; one for wavegain; one for ffmpeg.
- Move cli into a new entrypoints module.
- Update third-party libs.